### PR TITLE
feat: Add interactive celestial bodies learning page

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,11 +68,12 @@
                       Discover the wonders of space with Cosmos Observer. Get the latest news, observe celestial events, and access valuable resources.
                     </h2>
                   </div>
-                  <button
+                  <a
+                    href="learn_more.html"
                     class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#3d98f4] text-white text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
                   >
                     <span class="truncate">Learn More</span>
-                  </button>
+                  </a>
                 </div>
               </div>
             </div>

--- a/learn_more.html
+++ b/learn_more.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Learn More - Cosmos Observer</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Space+Grotesk%3Awght%40400%3B500%3B700"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+        .celestial-item {
+            /* Tailwind classes: cursor-pointer py-1 hover:text-[#3d98f4] transition-colors duration-150 */
+        }
+        .popup-overlay {
+            /* Tailwind classes: fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 */
+            /* Initially hidden, will be shown by JS */
+        }
+        .popup-content {
+            /* Tailwind classes: bg-[#1f2937] p-6 rounded-lg border border-gray-700 shadow-xl relative text-white */
+            /* min-width: 300px; max-width: 500px; */
+        }
+        .close-btn {
+            /* Tailwind classes: absolute top-3 right-3 text-gray-400 hover:text-white cursor-pointer */
+        }
+    </style>
+</head>
+<body class="bg-[#111418] text-white" style='font-family: "Space Grotesk", "Noto Sans", sans-serif;'>
+    <div class="relative flex size-full min-h-screen flex-col bg-[#111418] dark group/design-root overflow-x-hidden">
+        <div class="layout-container flex h-full grow flex-col">
+            <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#283039] px-10 py-3">
+                <div class="flex items-center gap-4 text-white">
+                    <div class="size-4">
+                        <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path
+                                d="M24 4C25.7818 14.2173 33.7827 22.2182 44 24C33.7827 25.7818 25.7818 33.7827 24 44C22.2182 33.7827 14.2173 25.7818 4 24C14.2173 22.2182 22.2182 14.2173 24 4Z"
+                                fill="currentColor"
+                            ></path>
+                        </svg>
+                    </div>
+                    <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Cosmos Observer</h2>
+                </div>
+                <div class="flex flex-1 justify-end gap-8">
+                    <div class="flex items-center gap-9">
+                        <a class="text-white text-sm font-medium leading-normal" href="index.html">Home</a>
+                        <a class="text-white text-sm font-medium leading-normal" href="#">News</a>
+                        <a class="text-white text-sm font-medium leading-normal" href="#">Observations</a>
+                        <a class="text-white text-sm font-medium leading-normal" href="#">Events</a>
+                        <a class="text-white text-sm font-medium leading-normal" href="#">Resources</a>
+                    </div>
+                    <button
+                        class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 bg-[#283039] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+                    >
+                        <div class="text-white" data-icon="MagnifyingGlass" data-size="20px" data-weight="regular">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+                                <path d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"></path>
+                            </svg>
+                        </div>
+                    </button>
+                    <div
+                        class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+                        style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuDrdfRxsuDnA1CdwEGo8ktDvcoZFVQaDpGyrYff0ZUcrBaKvmUSnTeRWybQdA4ExkgX8gTnOhYvy7FNHLVxIDt0iPywzluw0Y9jBMFvofi35uIdTzScl5ABCmGQXOODHo53Mw7C79pYdk33YAYho1kPxXnn_wAG9ttfWqKyMeemGD_BUdZQVxAZGy7Ygvu03l3_d9oqJlgK0ia3EwX1biUpQAb-ChgEC3Eo94453-EbCQmqpFJ4JkMHwEiX95dQMZ00oB73WVNv1euw");'
+                    ></div>
+                </div>
+            </header>
+
+            <main class="px-40 flex flex-1 justify-center py-5">
+                <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+                    <h1 class="text-3xl font-bold my-8 text-center">Learn More About Celestial Bodies</h1>
+                    <ul class="list-none pl-5 space-y-2">
+                        <li id="celestial-sun" class="celestial-item cursor-pointer py-1 hover:text-[#3d98f4] transition-colors duration-150 text-lg">Sun</li>
+                        <li id="celestial-earth" class="celestial-item cursor-pointer py-1 hover:text-[#3d98f4] transition-colors duration-150 text-lg">Earth</li>
+                    </ul>
+
+                    <div id="popup-sun" class="popup-overlay hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center z-50">
+                        <div class="popup-content bg-[#1f2937] p-6 rounded-lg border border-gray-700 shadow-xl relative text-white min-w-[300px] max-w-[500px]">
+                            <button class="close-btn absolute top-3 right-3 text-gray-400 hover:text-white cursor-pointer">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256"><path d="M208.49,191.51a12,12,0,0,1-17,17L128,145,64.49,208.49a12,12,0,0,1-17-17L111,128,47.51,64.49a12,12,0,0,1,17-17L128,111l63.51-63.52a12,12,0,0,1,17,17L145,128Z"></path></svg>
+                            </button>
+                            <h2 class="text-xl font-bold mb-4">Sun</h2>
+                            <p>The Sun is the star at the center of the Solar System. It is a nearly perfect ball of hot plasma, heated to incandescence by nuclear fusion reactions in its core.</p>
+                        </div>
+                    </div>
+                    <div id="popup-earth" class="popup-overlay hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center z-50">
+                        <div class="popup-content bg-[#1f2937] p-6 rounded-lg border border-gray-700 shadow-xl relative text-white min-w-[300px] max-w-[500px]">
+                            <button class="close-btn absolute top-3 right-3 text-gray-400 hover:text-white cursor-pointer">
+                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256"><path d="M208.49,191.51a12,12,0,0,1-17,17L128,145,64.49,208.49a12,12,0,0,1-17-17L111,128,47.51,64.49a12,12,0,0,1,17-17L128,111l63.51-63.52a12,12,0,0,1,17,17L145,128Z"></path></svg>
+                            </button>
+                            <h2 class="text-xl font-bold mb-4">Earth</h2>
+                            <p>Earth is the third planet from the Sun and the only astronomical object known to harbor life. About 29.2% of Earth's surface is land consisting of continents and islands.</p>
+                        </div>
+                    </div>
+                </div>
+            </main>
+
+            <footer class="flex justify-center">
+                <div class="flex max-w-[960px] flex-1 flex-col">
+                    <footer class="flex flex-col gap-6 px-5 py-10 text-center @container">
+                        <div class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
+                            <a class="text-[#9cabba] text-base font-normal leading-normal min-w-40" href="#">About</a>
+                            <a class="text-[#9cabba] text-base font-normal leading-normal min-w-40" href="#">Contact</a>
+                            <a class="text-[#9cabba] text-base font-normal leading-normal min-w-40" href="#">Privacy Policy</a>
+                        </div>
+                        <div class="flex flex-wrap justify-center gap-4">
+                            <a href="#">
+                                <div class="text-[#9cabba]" data-icon="TwitterLogo" data-size="24px" data-weight="regular">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                                        <path
+                                            d="M247.39,68.94A8,8,0,0,0,240,64H209.57A48.66,48.66,0,0,0,168.1,40a46.91,46.91,0,0,0-33.75,13.7A47.9,47.9,0,0,0,120,88v6.09C79.74,83.47,46.81,50.72,46.46,50.37a8,8,0,0,0-13.65,4.92c-4.31,47.79,9.57,79.77,22,98.18a110.93,110.93,0,0,0,21.88,24.2c-15.23,17.53-39.21,26.74-39.47,26.84a8,8,0,0,0-3.85,11.93c.75,1.12,3.75,5.05,11.08,8.72C53.51,229.7,65.48,232,80,232c70.67,0,129.72-54.42,135.75-124.44l29.91-29.9A8,8,0,0,0,247.39,68.94Zm-45,29.41a8,8,0,0,0-2.32,5.14C196,166.58,143.28,216,80,216c-10.56,0-18-1.4-23.22-3.08,11.51-6.25,27.56-17,37.88-32.48A8,8,0,0,0,92,169.08c-.47-.27-43.91-26.34-44-96,16,13,45.25,33.17,78.67,38.79A8,8,0,0,0,136,104V88a32,32,0,0,1,9.6-22.92A30.94,30.94,0,0,1,167.9,56c12.66.16,24.49,7.88,29.44,19.21A8,8,0,0,0,204.67,80h16Z"
+                                        ></path>
+                                    </svg>
+                                </div>
+                            </a>
+                            <a href="#">
+                                <div class="text-[#9cabba]" data-icon="InstagramLogo" data-size="24px" data-weight="regular">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                                        <path
+                                            d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160ZM176,24H80A56.06,56.06,0,0,0,24,80v96a56.06,56.06,0,0,0,56,56h96a56.06,56.06,0,0,0,56-56V80A56.06,56.06,0,0,0,176,24Zm40,152a40,40,0,0,1-40,40H80a40,40,0,0,1-40-40V80A40,40,0,0,1,80,40h96a40,40,0,0,1,40,40ZM192,76a12,12,0,1,1-12-12A12,12,0,0,1,192,76Z"
+                                        ></path>
+                                    </svg>
+                                </div>
+                            </a>
+                            <a href="#">
+                                <div class="text-[#9cabba]" data-icon="FacebookLogo" data-size="24px" data-weight="regular">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                                        <path
+                                            d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm8,191.63V152h24a8,8,0,0,0,0-16H136V112a16,16,0,0,1,16-16h16a8,8,0,0,0,0-16H152a32,32,0,0,0-32,32v24H96a8,8,0,0,0,0,16h24v63.63a88,88,0,1,1,16,0Z"
+                                        ></path>
+                                    </svg>
+                                </div>
+                            </a>
+                        </div>
+                        <p class="text-[#9cabba] text-base font-normal leading-normal">@2024 Cosmos Observer. All rights reserved.</p>
+                    </footer>
+                </div>
+            </footer>
+        </div>
+    </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // Sun
+    const sunItem = document.getElementById('celestial-sun');
+    const sunPopup = document.getElementById('popup-sun');
+    // Earth
+    const earthItem = document.getElementById('celestial-earth');
+    const earthPopup = document.getElementById('popup-earth');
+
+    // Function to open a popup
+    function openPopup(popupElement) {
+      if (popupElement) {
+        popupElement.classList.remove('hidden');
+      }
+    }
+
+    // Function to close a popup
+    function closePopup(popupElement) {
+      if (popupElement) {
+        popupElement.classList.add('hidden');
+      }
+    }
+
+    // Event listeners for celestial items
+    if (sunItem && sunPopup) {
+      sunItem.addEventListener('click', () => {
+        openPopup(sunPopup);
+      });
+    }
+
+    if (earthItem && earthPopup) {
+      earthItem.addEventListener('click', () => {
+        openPopup(earthPopup);
+      });
+    }
+
+    // Event listeners for all close buttons
+    const closeButtons = document.querySelectorAll('.close-btn');
+    closeButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        // Find the closest parent popup-overlay and close it
+        const popupToClose = button.closest('.popup-overlay');
+        closePopup(popupToClose);
+      });
+    });
+
+    // Event listeners for popup overlays (to close when clicking outside content)
+    const popupOverlays = document.querySelectorAll('.popup-overlay');
+    popupOverlays.forEach(overlay => {
+      overlay.addEventListener('click', (event) => {
+        // If the click is on the overlay itself (event.target)
+        // and not on a descendant of popup-content
+        if (event.target === overlay) {
+          closePopup(overlay);
+        }
+      });
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new page `learn_more.html` that features a list of celestial bodies. Currently, "Sun" and "Earth" are included.

Key features:
- Clicking on a celestial body name opens a modal pop-up with information.
- Pop-ups include sample descriptions for the Sun and Earth.
- Pop-ups can be closed using an 'X' button or by clicking outside the pop-up content.
- The page is styled with Tailwind CSS, consistent with the rest of the site.
- The "Learn More" button on the `index.html` page now links to this new `learn_more.html` page.